### PR TITLE
Feature/rabobank dialect support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.chessix.sepa</groupId>
     <artifactId>pain-generator</artifactId>
     <packaging>jar</packaging>
-    <version>1.5</version>
+    <version>1.6</version>
     <name>SEPA PAIN Generator</name>
     <description>Library for creating SEPA PAIN files</description>
     <url>http://www.chess-ix.com</url>

--- a/src/main/java/com/chessix/sepa/pain/Dialect.java
+++ b/src/main/java/com/chessix/sepa/pain/Dialect.java
@@ -1,0 +1,11 @@
+package com.chessix.sepa.pain;
+
+/**
+ * Banks each have a different interpretation of the standard. Control which bank to adhere to via the dialect.
+ */
+public enum Dialect {
+
+    DEFAULT,
+    ING,
+    RABOBANK
+}

--- a/src/main/java/com/chessix/sepa/pain/DialectHandler.java
+++ b/src/main/java/com/chessix/sepa/pain/DialectHandler.java
@@ -1,0 +1,33 @@
+package com.chessix.sepa.pain;
+
+import com.chessix.sepa.pain.util.DocumentUtils;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.Date;
+
+/**
+ * This class handles all the values that are different between dialects
+ */
+public class DialectHandler {
+
+    private Dialect dialect;
+
+    public DialectHandler(Dialect dialect) {
+        this.dialect = dialect;
+    }
+
+    public XMLGregorianCalendar getCreDtTm(Date date) {
+        switch (dialect) {
+            case RABOBANK:
+                XMLGregorianCalendar xmlGregorianCalendar = DocumentUtils.toXmlDateTimeUTC(date);
+                xmlGregorianCalendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
+                xmlGregorianCalendar.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
+                return xmlGregorianCalendar;
+            case ING:
+            case DEFAULT:
+            default:
+                return DocumentUtils.toXmlDateTimeUTC(date);
+        }
+    }
+}

--- a/src/main/java/com/chessix/sepa/pain/DocumentService.java
+++ b/src/main/java/com/chessix/sepa/pain/DocumentService.java
@@ -43,7 +43,7 @@ public interface DocumentService {
      * See {@link #generatePain00100103(OutputStream, InitiatingParty, Debtor, List, Date, String)}, but with an additional
      * paymentInfoId parameter which gets stored in the PmtInfId element of the pain 001 file.
      */
-    public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, String paymentInfoId);
+    public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, String paymentInfoId, Dialect dialect);
 
 
 }

--- a/src/main/java/com/chessix/sepa/pain/DocumentService.java
+++ b/src/main/java/com/chessix/sepa/pain/DocumentService.java
@@ -41,5 +41,11 @@ public interface DocumentService {
 	 */
 	public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate);
 
+    /**
+     * See {@link #generatePain00100103(OutputStream, InitiatingParty, Debtor, List, Date, String)}, but with an additional
+     * paymentInfoId parameter which gets stored in the PmtInfId element of the pain 001 file.
+     */
+    public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, String paymentInfoId);
+
 
 }

--- a/src/main/java/com/chessix/sepa/pain/DocumentService.java
+++ b/src/main/java/com/chessix/sepa/pain/DocumentService.java
@@ -23,23 +23,21 @@ public interface DocumentService {
      */
     public void generatePain00800202(OutputStream outputStream, Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions);
 
-
     /**
      * Generates a PAIN.008.001.02 string
      * @return a formatted String containing the PAIN008.02.02 xml
      */
-    public String generatePain00800102(Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions);
-
+    public String generatePain00800102(Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions, boolean useBatchBooking, Dialect dialect);
 
     /**
      * Writes a PAIN.008.001.02 to the specified OutputStream. Will not close the stream.
      */
-    public void generatePain00800102(OutputStream outputStream, Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions);
+    public void generatePain00800102(OutputStream outputStream, Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions, boolean useBatchBooking, Dialect dialect);
 
-	/**
-	 * Writes a PAIN.001.001.03 to the specified OutputStream. Will not close the stream.
-	 */
-	public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate);
+        /**
+         * Writes a PAIN.001.001.03 to the specified OutputStream. Will not close the stream.
+         */
+	public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, Dialect dialect);
 
 
 }

--- a/src/main/java/com/chessix/sepa/pain/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/chessix/sepa/pain/impl/DocumentServiceImpl.java
@@ -2,11 +2,6 @@ package com.chessix.sepa.pain.impl;
 
 import com.chessix.sepa.pain.*;
 
-import java.io.OutputStream;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.Date;
-import java.util.List;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
@@ -14,6 +9,11 @@ import javax.xml.bind.Marshaller;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Main implementation for generating PAIN files.
@@ -48,8 +48,8 @@ public class DocumentServiceImpl implements DocumentService {
     }
 
     @Override
-    public String generatePain00800102(Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions) {
-        Pain00800102 pain00800102 = new Pain00800102(creditor, initiatingParty, firstTransactions, recurringTransactions);
+    public String generatePain00800102(Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions, boolean useBatchBooking, Dialect dialect) {
+        Pain00800102 pain00800102 = new Pain00800102(creditor, initiatingParty, firstTransactions, recurringTransactions, useBatchBooking, dialect);
         StringWriter writer = new StringWriter();
         try {
             generate(pain00800102.createDocument(), writer);
@@ -62,8 +62,8 @@ public class DocumentServiceImpl implements DocumentService {
     }
 
     @Override
-    public void generatePain00800102(OutputStream outputStream, Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions) {
-        Pain00800102 pain00800102 = new Pain00800102(creditor, initiatingParty, firstTransactions, recurringTransactions);
+    public void generatePain00800102(OutputStream outputStream, Creditor creditor, InitiatingParty initiatingParty, FirstTransactions firstTransactions, RecurringTransactions recurringTransactions, boolean useBatchBooking, Dialect dialect) {
+        Pain00800102 pain00800102 = new Pain00800102(creditor, initiatingParty, firstTransactions, recurringTransactions,useBatchBooking, dialect);
         try {
             generate(pain00800102.createDocument(), outputStream);
         } catch (JAXBException e) {
@@ -74,8 +74,8 @@ public class DocumentServiceImpl implements DocumentService {
     }
 
 	@Override
-	public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate) {
-		Pain00100103 pain00100103 = new Pain00100103(initiatingParty, debtor, transactions, executionDate);
+	public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, Dialect dialect) {
+		Pain00100103 pain00100103 = new Pain00100103(initiatingParty, debtor, transactions, executionDate, dialect);
 		try {
 			pain00100103.generate(outputStream);
 		} catch (JAXBException e) {

--- a/src/main/java/com/chessix/sepa/pain/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/chessix/sepa/pain/impl/DocumentServiceImpl.java
@@ -14,6 +14,7 @@ import javax.xml.bind.Marshaller;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import com.chessix.sepa.pain.util.DocumentUtils;
 
 /**
  * Main implementation for generating PAIN files.
@@ -73,10 +74,16 @@ public class DocumentServiceImpl implements DocumentService {
         }
     }
 
+    @Override
+    public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate) {
+        String paymentInfoId = DocumentUtils.createUniqueId();
+        generatePain00100103(outputStream, initiatingParty, debtor, transactions, executionDate, paymentInfoId);
+    }
+
 	@Override
-	public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate) {
-		Pain00100103 pain00100103 = new Pain00100103(initiatingParty, debtor, transactions, executionDate);
-		try {
+	public void generatePain00100103(OutputStream outputStream, InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, String paymentInfoId) {
+		Pain00100103 pain00100103 = new Pain00100103(initiatingParty, debtor, transactions, executionDate, paymentInfoId);
+        try {
 			pain00100103.generate(outputStream);
 		} catch (JAXBException e) {
 			throw new IllegalStateException(EXCEPTION_MESSAGE, e);

--- a/src/main/java/com/chessix/sepa/pain/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/chessix/sepa/pain/impl/DocumentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.chessix.sepa.pain.impl;
 
 import com.chessix.sepa.pain.*;
+import com.chessix.sepa.pain.util.DocumentUtils;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -14,7 +15,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Date;
 import java.util.List;
-import com.chessix.sepa.pain.util.DocumentUtils;
 
 /**
  * Main implementation for generating PAIN files.

--- a/src/main/java/com/chessix/sepa/pain/impl/Pain00100103.java
+++ b/src/main/java/com/chessix/sepa/pain/impl/Pain00100103.java
@@ -1,8 +1,6 @@
 package com.chessix.sepa.pain.impl;
 
-import com.chessix.sepa.pain.Debtor;
-import com.chessix.sepa.pain.InitiatingParty;
-import com.chessix.sepa.pain.Transaction;
+import com.chessix.sepa.pain.*;
 import com.chessix.sepa.pain.util.DocumentUtils;
 import generated.pain00100103.AccountIdentification4Choice;
 import generated.pain00100103.ActiveOrHistoricCurrencyAndAmount;
@@ -40,11 +38,15 @@ public class Pain00100103 {
 	private Date executionDate;
 	private List<Transaction> transactions;
 
-	public Pain00100103(InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate) {
+	private DialectHandler dialectHandler;
+
+	public Pain00100103(InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, Dialect dialect) {
 		this.initiatingParty = initiatingParty;
 		this.transactions = transactions;
 		this.debtor = debtor;
 		this.executionDate = executionDate;
+
+		dialectHandler = new DialectHandler(dialect);
 		initializeDocument();
 	}
 
@@ -65,7 +67,7 @@ public class Pain00100103 {
 		// Group Header
 		GroupHeader32 hdr = new GroupHeader32();
 		hdr.setMsgId(DocumentUtils.createUniqueId());
-		hdr.setCreDtTm(DocumentUtils.toXmlDateTimeUTC(new Date()));
+		hdr.setCreDtTm(dialectHandler.getCreDtTm(new Date()));
 		hdr.setNbOfTxs("" + transactions.size());
 		PartyIdentification32 party = new PartyIdentification32();
 		party.setNm(initiatingParty.getName());

--- a/src/main/java/com/chessix/sepa/pain/impl/Pain00100103.java
+++ b/src/main/java/com/chessix/sepa/pain/impl/Pain00100103.java
@@ -39,12 +39,14 @@ public class Pain00100103 {
 	private Debtor debtor;
 	private Date executionDate;
 	private List<Transaction> transactions;
+    private String paymentInfoId;
 
-	public Pain00100103(InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate) {
+	public Pain00100103(InitiatingParty initiatingParty, Debtor debtor, List<Transaction> transactions, Date executionDate, String paymentInfoId) {
 		this.initiatingParty = initiatingParty;
 		this.transactions = transactions;
 		this.debtor = debtor;
 		this.executionDate = executionDate;
+		this.paymentInfoId = paymentInfoId;
 		initializeDocument();
 	}
 
@@ -74,7 +76,7 @@ public class Pain00100103 {
 
 		// Payment Information
 		PaymentInstructionInformation3 pi = new PaymentInstructionInformation3();
-		pi.setPmtInfId(DocumentUtils.createUniqueId());
+		pi.setPmtInfId(paymentInfoId);
 		pi.setPmtMtd(PaymentMethod3Code.TRF);
 		PaymentTypeInformation19 pti = new PaymentTypeInformation19();
 		ServiceLevel8Choice serviceLevel8Choice = new ServiceLevel8Choice();

--- a/src/main/java/com/chessix/sepa/pain/util/DocumentUtils.java
+++ b/src/main/java/com/chessix/sepa/pain/util/DocumentUtils.java
@@ -30,7 +30,7 @@ public class DocumentUtils {
      * Returns a XMLGregorianCalender (xml:dateTime) in UTC
      *
      * @param date the date to convert
-     * @return dateTime in UTC e.g. 2012-03-14T12:34.567Z
+     * @return dateTime in UTC e.g. 2012-03-14T12:34.56.789Z
      */
     public static XMLGregorianCalendar toXmlDateTimeUTC(Date date) {
         if (date != null) {

--- a/src/main/java/com/chessix/sepa/pain/util/DocumentUtils.java
+++ b/src/main/java/com/chessix/sepa/pain/util/DocumentUtils.java
@@ -30,7 +30,7 @@ public class DocumentUtils {
      * Returns a XMLGregorianCalender (xml:dateTime) in UTC
      *
      * @param date the date to convert
-     * @return dateTime in UTC e.g. 2012-03-14T12:34.56.789Z
+     * @return dateTime in UTC e.g. 2012-03-14T12:34:56.789Z
      */
     public static XMLGregorianCalendar toXmlDateTimeUTC(Date date) {
         if (date != null) {

--- a/src/test/java/com/chessix/sepa/pain/DialectHandlerTest.java
+++ b/src/test/java/com/chessix/sepa/pain/DialectHandlerTest.java
@@ -1,0 +1,31 @@
+package com.chessix.sepa.pain;
+
+
+import org.junit.Test;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.text.ParseException;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class DialectHandlerTest {
+
+	private DialectHandler defaultDialectHandler = new DialectHandler(Dialect.DEFAULT);
+	private DialectHandler raboDialectHandler = new DialectHandler(Dialect.RABOBANK);
+
+	@Test
+	public void testGetCreDtTm() throws ParseException {
+		// Prepare
+		Date date = new Date(1484929215302L);
+
+		// Execute
+		XMLGregorianCalendar defaultCreDtTmD = defaultDialectHandler.getCreDtTm(date);
+		XMLGregorianCalendar raboCreDtTmD = raboDialectHandler.getCreDtTm(date);
+
+		// Verify
+		assertEquals("2017-01-20T16:20:15.302Z", defaultCreDtTmD.toString());
+		assertEquals("2017-01-20T16:20:15", raboCreDtTmD.toString());
+	}
+
+}


### PR DESCRIPTION
- Allow control over the PmtInfId so it can be used for reconciliation.
- Add support for generating PAIN files for Rabobank by using Dialects. The consumer now has to specify which Dialect he/she wants to use, because Rabobank and ING have different interpretations of the standard. 
- Add batch booking as an input parameter for PAIN 008 files, since this is a configuration.